### PR TITLE
Remove repetitive conditional from dodge workshop

### DIFF
--- a/dodge/game.js
+++ b/dodge/game.js
@@ -27,8 +27,6 @@ function draw() {
   } else {
     if (enemy.overlap(player)) {
       isGameOver = true;
-    }
-    if (enemy.overlap(player)) {
       gameOver();
     }
     background(backgroundImage);

--- a/dodge/game.js
+++ b/dodge/game.js
@@ -27,7 +27,6 @@ function draw() {
   } else {
     if (enemy.overlap(player)) {
       isGameOver = true;
-      gameOver();
     }
     background(backgroundImage);
     if (keyDown(RIGHT_ARROW) && player.position.x < (width - (playerImage.width / 2))) {


### PR DESCRIPTION
As far as I can tell we can just `3dd` right here, as the value being checked (`enemy.overlap(player)`) cannot have changed during this time and the first conditional (checking `isGameOver`) will fire on the next redraw.